### PR TITLE
change baud rate to 115200 (to justify mros2-asp3)

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ After that, you will find an executable binary is created in the path below.
 cmake_build/NUCLEO_F429ZI/develop/GCC_ARM/mros2-mbed.bin
 ```
 3. Connect the PC and Mbed Board with USB and LAN cables.
-4. Open Serial Console of the Mbed board. (9600bps)
+4. Open Serial Console of the Mbed board. (115200bps)
 5. Copy the executable binary above to the Mbed Board.
     (you may find it in the Nautilus file manager as NODE_F429ZI or F797ZI).
 ```

--- a/README.md
+++ b/README.md
@@ -30,8 +30,8 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 git clone https://github.com/mROS-base/mros2-mbed
 cd mros2-mbed
 docker run --rm -it --mount=type=bind,source="$(pwd)",destination=/var/mbed -w /var/mbed \
-   ghcr.io/armmbed/mbed-os-env \
-   /bin/bash -c "mbed-tools deploy && mbed-tools compile -m NUCLEO_F429ZI -t GCC_ARM"
+  ghcr.io/armmbed/mbed-os-env \
+  /bin/bash -c "mbed-tools deploy && mbed-tools compile -m NUCLEO_F429ZI -t GCC_ARM"
 ```
 After that, you will find an executable binary is created in the path below.
 ```
@@ -55,15 +55,16 @@ ready to pub/sub message
 ```
 6. On the PC console, type the command below.
 ```
-docker run --rm -it --net=host  ros:dashing /bin/bash -c  "source /opt/ros/dashing/setup.bash &&
-       cd &&
-       git clone https://github.com/mROS-base/mros2-host-examples &&
-       cd mros2-host-examples &&
-       colcon build && source install/setup.bash &&
-       (ros2 run mros2_echoback sub_node &) &&
-       echo 'wait for sub_node connection' &&
-       sleep 10 &&
-       ros2 run mros2_echoback pub_node"
+docker run --rm -it --net=host ros:dashing /bin/bash \
+  -c "source /opt/ros/dashing/setup.bash &&
+  cd &&
+  git clone https://github.com/mROS-base/mros2-host-examples &&
+  cd mros2-host-examples &&
+  colcon build && source install/setup.bash &&
+  (ros2 run mros2_echoback sub_node &) &&
+  echo 'wait for sub_node connection' &&
+  sleep 10 &&
+  ros2 run mros2_echoback pub_node"
 ```
 Then, we can confirm the communication between the PC and Mbed board via ROS2.
 ```

--- a/README.md
+++ b/README.md
@@ -60,7 +60,8 @@ docker run --rm -it --net=host ros:dashing /bin/bash \
   cd &&
   git clone https://github.com/mROS-base/mros2-host-examples &&
   cd mros2-host-examples &&
-  colcon build && source install/setup.bash &&
+  colcon build --packages-select mros2_echoback &&
+  source install/setup.bash &&
   (ros2 run mros2_echoback sub_node &) &&
   echo 'wait for sub_node connection' &&
   sleep 10 &&

--- a/mbed_app.json
+++ b/mbed_app.json
@@ -1,7 +1,7 @@
 {
     "target_overrides": {
         "*": {
-            "platform.stdio-baud-rate": 9600,
+            "platform.stdio-baud-rate": 115200,
             "rtos.main-thread-stack-size": 8192,
             "lwip.pbuf-pool-size": 20
         },


### PR DESCRIPTION
Since I am working for this repository along with [mros2-asp3-f767zi](https://github.com/mROS-base/mros2-asp3-f767zi), it is better to justify the baud rate for them. 
@smoriemb Could you accept to change the baud rate to 115200?

And also, I've added some improvement for README. We are now preparing another ROS 2 packages for the host, so it's better to specify the package (with `--pacakges-select`) to keep the ability to build the host environment just in 5 minutes.