### PR TITLE
Support Foxy as the default distribution

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,25 +60,26 @@ docker run --rm -it --net=host ros:foxy /bin/bash \
   cd &&
   git clone https://github.com/mROS-base/mros2-host-examples &&
   cd mros2-host-examples &&
-  colcon build --packages-select mros2_echoback &&
+  colcon build --packages-select mros2_echoback_string &&
   source install/setup.bash &&
-  (ros2 run mros2_echoback sub_node &) &&
+  (ros2 run mros2_echoback_string sub_node &) &&
   echo 'wait for sub_node connection' &&
   sleep 10 &&
-  ros2 run mros2_echoback pub_node"
+  ros2 run mros2_echoback_string pub_node"
 ```
 Then, we can confirm the communication between the PC and Mbed board via ROS2.
 ```
 Cloning into 'mros2-host-examples'...
-remote: Enumerating objects: 35, done.
-remote: Counting objects: 100% (35/35), done.
-remote: Compressing objects: 100% (23/23), done.
-remote: Total 35 (delta 14), reused 29 (delta 11), pack-reused 0
-Unpacking objects: 100% (35/35), done.
-Starting >>> mros2_echoback
-Finished <<< mros2_echoback [8.14s]
+remote: Enumerating objects: 432, done.
+remote: Counting objects: 100% (432/432), done.
+remote: Compressing objects: 100% (272/272), done.
+remote: Total 432 (delta 237), reused 316 (delta 127), pack-reused 0
+Receiving objects: 100% (432/432), 42.50 KiB | 10.63 MiB/s, done.
+Resolving deltas: 100% (237/237), done.
+Starting >>> mros2_echoback_string
+Finished <<< mros2_echoback_string [5.28s]                     
 
-Summary: 1 package finished [8.38s]
+Summary: 1 package finished [5.39s]
 wait for sub_node connection
 [INFO] [pub_mros2]: Publishing msg: 'Hello, world! 0'
 [INFO] [mros2_sub]: Subscribed msg: 'Hello, world! 0'

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 - PC having an Ethernet port whose IP address is 192.168.11.x(x is not 2) and a docker environment.
 - Mbed board having an Ethernet port(listed above).
 2. Build Mbed executable binary using Mbed CLI2.
-(Please replace F429ZI with F797ZI if you use F767ZI)
+(Please replace F429ZI with F767ZI if you use F767ZI)
 ```
 git clone https://github.com/mROS-base/mros2-mbed
 cd mros2-mbed
@@ -40,7 +40,7 @@ cmake_build/NUCLEO_F429ZI/develop/GCC_ARM/mros2-mbed.bin
 3. Connect the PC and Mbed Board with USB and LAN cables.
 4. Open Serial Console of the Mbed board. (115200bps)
 5. Copy the executable binary above to the Mbed Board.
-    (you may find it in the Nautilus file manager as NODE_F429ZI or F797ZI).
+    (you may find it in the Nautilus file manager as NODE_F429ZI or F767ZI).
 ```
 mbed mros2 start!
 [MROS2LIB] mros2_init task start

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # mros2-mbed
 
 mROS 2 (formally `mros2`) realizes a agent-less and lightweight runtime environment compatible with ROS 2 for embedded devices.
-mROS 2 mainly offers pub/sub APIs compatible with [rclcpp](https://docs.ros2.org/dashing/api/rclcpp/index.html) for embedded devices.
+mROS 2 mainly offers pub/sub APIs compatible with [rclcpp](https://docs.ros2.org/foxy/api/rclcpp/index.html) for embedded devices.
 
 mROS 2 consists of communication library for pub/sub APIs, RTPS protocol, UDP/IP stack, and real-time kernel.
 This repository provides the reference implementation of mROS 2 that can be operated on the Mbed enabled board.
@@ -17,8 +17,8 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 
   - Kernel: [Mbed OS 6](https://github.com/ARMmbed/mbed-os)
 - Host environment
+  - [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
   - [ROS 2 Dashing Diademata](https://docs.ros.org/en/dashing/index.html) on Ubuntu 18.04 LTS
-  - [WiP] [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
 
 ## Getting Starred
 1. Prepare these items below.
@@ -55,8 +55,8 @@ ready to pub/sub message
 ```
 6. On the PC console, type the command below.
 ```
-docker run --rm -it --net=host ros:dashing /bin/bash \
-  -c "source /opt/ros/dashing/setup.bash &&
+docker run --rm -it --net=host ros:foxy /bin/bash \
+  -c "source /opt/ros/foxy/setup.bash &&
   cd &&
   git clone https://github.com/mROS-base/mros2-host-examples &&
   cd mros2-host-examples &&

--- a/mros2.lib
+++ b/mros2.lib
@@ -1,1 +1,1 @@
-https://github.com/mROS-base/mros2#main
+https://github.com/mROS-base/mros2#v0.2.1


### PR DESCRIPTION
With the great contribution from https://github.com/mROS-base/embeddedRTPS/pull/7 , mros2 can communicate with Foxy nodes now. I updated README to clarify this.

And also, I want to specify the version of mros2 in `mros2.lib`, because we maintain two targets at the same time, we cannot guarantee that the latest version of mros2 will always work with this repository. I am thinking of creating a PR that updates the version number when the version of mros2 is updated in the future. How do you think this policy? > @smoriemb 