### PR TITLE
Enhance README and examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,8 +242,8 @@ By using the following Codes on Keil Studio Cloud (a.k.a Mbed Online Complier), 
 
 - example application:
   - [mbed-os-example-mros2 (echoreply_string)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2/)
-  - [mbed-os-example-mros2-pub-twist (pub-twist)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2-pub-twist/)
-  - [mbed-os-example-mros2-sub-pose (sub-pose)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2-sub-pose/)
+  - [mbed-os-example-mros2-pub-twist (pub-twist)](https://os.mbed.com/users/smoritaemb/code/example-mbed-mros2-pub-twist/)
+  - [mbed-os-example-mros2-sub-pose (sub-pose)](https://os.mbed.com/users/smoritaemb/code/example-mbed-mros2-sub-pose/)
 - [mbed-mros2 (core library for mros2-mbed)](https://os.mbed.com/users/smoritaemb/code/mbed-mros2/)
 
 Please feel free to let us know in [Issues on this repository](https://github.com/mROS-base/mros2-mbed/issues) if you have any troubles or causes.

--- a/README.md
+++ b/README.md
@@ -20,7 +20,8 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
   - [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
   - [ROS 2 Dashing Diademata](https://docs.ros.org/en/dashing/index.html) on Ubuntu 18.04 LTS
 
-## Getting Starred
+## Getting Started
+
 1. Prepare these items below.
 - PC having an Ethernet port whose IP address is 192.168.11.x(x is not 2) and a docker environment.
 - Mbed board having an Ethernet port(listed above).

--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
     - [STM32 NUCLEO-F767ZI](https://www.st.com/en/evaluation-tools/nucleo-f767zi.html)
     - [Seeed Arch Max V1.1](https://wiki.seeedstudio.com/Arch_Max_v1.1/)
   - Kernel: [Mbed OS 6](https://github.com/ARMmbed/mbed-os)
+  - check the Mbed website for [the boards list](https://os.mbed.com/platforms/?q=&Mbed+OS+6=Bare+metal&Mbed+OS+6=RTOS&Communication=Ethernet) where mros2 may work. Please let us know if you find a new board that can work as mros2 enabled device.
 - Host environment
   - [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
   - [ROS 2 Dashing Diademata](https://docs.ros.org/en/dashing/index.html) on Ubuntu 18.04 LTS

--- a/README.md
+++ b/README.md
@@ -235,6 +235,19 @@ int main(int argc, char * argv[])
 <snip.>
 ```
 
+## TIPS: getting started in 5 minutes with the online compiler
+
+We also provide an online development environment for mros2-mbed. 
+By using the following Codes on Keil Studio Cloud (a.k.a Mbed Online Complier), you can try out the power of mros2 just in 5 minutes (we wish :D
+
+- example application:
+  - [mbed-os-example-mros2 (echoreply_string)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2/)
+  - [mbed-os-example-mros2-pub-twist (pub-twist)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2-pub-twist/)
+  - [mbed-os-example-mros2-sub-pose (sub-pose)](https://os.mbed.com/users/smoritaemb/code/mbed-os-example-mros2-sub-pose/)
+- [mbed-mros2 (core library for mros2-mbed)](https://os.mbed.com/users/smoritaemb/code/mbed-mros2/)
+
+Please feel free to let us know in [Issues on this repository](https://github.com/mROS-base/mros2-mbed/issues) if you have any troubles or causes.
+
 ## Submodules and Licenses
 
 The source code of this repository itself is published under [Apache License 2.0](https://github.com/mROS-base/mros2/blob/main/LICENSE).  

--- a/README.md
+++ b/README.md
@@ -20,12 +20,20 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 - Host environment
   - [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
   - [ROS 2 Dashing Diademata](https://docs.ros.org/en/dashing/index.html) on Ubuntu 18.04 LTS
+- Network setting
+  - Make sure both the device and the host are connected to the wired network with the following setting, since they are statically configured to the board (you can change them in `app.cpp`).
+    - IP address: 192.168.11.x
+      - .2 will be assigned to the board
+    - Netmask: 255.255.255.0
+    - Gateway: 192.168.11.1
+  - The firewall on the host (Ubuntu) needs to be disabled for ROS 2 (DDS) communication (e.g. `$ sudo ufw disable`)
+  - If the host is connected to the Internet other than wired network (e.g., Wi-Fi), communication with mros2 may not work properly. In that case, please turn off them.
 
 ## Getting Started
 
 1. Prepare these items below.
-- PC having an Ethernet port whose IP address is 192.168.11.x(x is not 2) and a docker environment.
-- Mbed board having an Ethernet port(listed above).
+- Host PC having an Ethernet port whose network is set to the above and a docker environment.
+- Mbed board having an Ethernet port (listed above).
 2. Build Mbed executable binary using Mbed CLI2.
 ```
 git clone https://github.com/mROS-base/mros2-mbed

--- a/workspace/echoreply_string/app.cpp
+++ b/workspace/echoreply_string/app.cpp
@@ -48,7 +48,7 @@ int main() {
   mros2::Node node = mros2::Node::create_node("mros2_node");
   pub = node.create_publisher<std_msgs::msg::String>("to_linux", 10);
   sub = node.create_subscription<std_msgs::msg::String>("to_stm", 10, userCallback);
-
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message\r\n");
 
   mros2::spin();

--- a/workspace/pub_float32/app.cpp
+++ b/workspace/pub_float32/app.cpp
@@ -37,6 +37,7 @@ int main() {
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
   mros2::Publisher pub = node.create_publisher<std_msgs::msg::Float32>("to_linux", 10);
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message\r\n");
 
   std_msgs::msg::Float32 msg;

--- a/workspace/pub_twist/app.cpp
+++ b/workspace/pub_twist/app.cpp
@@ -38,6 +38,7 @@ int main() {
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
   mros2::Publisher pub = node.create_publisher<geometry_msgs::msg::Twist>("cmd_vel", 10);
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message\r\n");
 
   geometry_msgs::msg::Vector3 linear;

--- a/workspace/sub_pose/app.cpp
+++ b/workspace/sub_pose/app.cpp
@@ -42,7 +42,7 @@ int main() {
 
   mros2::Node node = mros2::Node::create_node("sub_pose");
   mros2::Subscriber sub = node.create_subscription<geometry_msgs::msg::Pose>("cmd_vel", 10, userCallback);
-  
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message");
 
   mros2::spin();

--- a/workspace/sub_uint16/app.cpp
+++ b/workspace/sub_uint16/app.cpp
@@ -42,7 +42,7 @@ int main() {
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
   mros2::Subscriber sub = node.create_subscription<std_msgs::msg::UInt16>("to_stm", 10, userCallback);
-
+  osDelay(100);
   MROS2_INFO("ready to pub/sub message\r\n");
 
   mros2::spin();


### PR DESCRIPTION
I added some improvements about README and examples

- fix tiny typo https://github.com/mROS-base/mros2-mbed/commit/bdbbb65f950a22107dd04cabb3adb293746db2e4
- add URL of the board list where mros2-mbed may work https://github.com/mROS-base/mros2-mbed/commit/f7a40d36af41b05a2039a6f4ddf99e47017e12c1
- add description about network setting https://github.com/mROS-base/mros2-mbed/commit/4d7c5bfb2b4cdd5688f727a47cd4d7370b0fc19f
  - A friend of mine tried this repository, but it didn't work right away due to network configuration issues. This seems to be a FAQ, so I decided to explain it in detail.
- add description about online compiler https://github.com/mROS-base/mros2-mbed/commit/372a3f6e4ad9a1cf36b0d3c2a084b40c79835902
  - The experience with the online compiler is so awesome, but we haven't shown it in this repository.
  - I noticed that the Mbed Online Compiler has been deprecated and switched to Keil Studio Cloud. I try this with 3 examples for mros2-mbed, but it was not worried at all.
- insert `osDelay(100)` to wait create_publisher/_subscription https://github.com/mROS-base/mros2-mbed/commit/9fcade071fc3e39173a7ac4f6a9209edcc8456ea)
  - The process of create_publisher and _subscription, which are executed concurrently as a system task, takes a little time. So I want to wait them by inserting `osDelay(100)` after them in app.cfg.
