### PR TITLE
enable build on native env where mbed-tools was installed

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 1. Prepare these items below.
 - Host PC having an Ethernet port whose network is set to the above and a docker environment.
 - Mbed board having an Ethernet port (listed above).
-2. Build Mbed executable binary using Mbed CLI2.
+2. Build Mbed executable binary using [the Docker environment for Mbed CLI2](https://github.com/ARMmbed/mbed-os/pkgs/container/mbed-os-env).  
+(You can also use the native environment where MBed CLI2 could work well. Please add `native` to 4th arg. (see [the example instruction to prepare native env](https://github.com/mROS-base/mros2-mbed/commit/90225c77e07e5cedc8473285b457827cb047e481)))
 ```
 git clone https://github.com/mROS-base/mros2-mbed
 cd mros2-mbed

--- a/build.bash
+++ b/build.bash
@@ -53,6 +53,7 @@ then
     echo "INFO: build operation will be executed on native env"
     DOCKERCMD_PRE=""
     DOCKERCMD_SUF=""
+    export APPNAME=${APPNAME}
   elif [ ${4} = "docker" ];
   then
     echo "INFO: build operation will be executed on dokcer env"


### PR DESCRIPTION
This PR enables us to build on the native environment where MBed CLI 2 could successfully operate.
To use this feature, add `native` option to `build.bash` as the 4th argument.

Effect on RPi4/Ubuntu20:
```
$ time build.bash all NUCLEO_H743ZI2 mturtle_teleop docker
(snipped)

real	14m8.806s
user	0m0.727s
sys	0m0.607s

$ time build.bash all NUCLEO_H743ZI2 mturtle_teleop native
(snipped)

real	10m24.181s
user	24m53.985s
sys	10m22.365s
```
