### PR TITLE
track embeddedRTPS in mROS 2 to the latest used in embeddedRTPS-STM32

### DIFF
--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -25,6 +25,9 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #ifndef RTPS_CONFIG_H
 #define RTPS_CONFIG_H
 
+/* added for mROS 2 */
+#include "conversion.h"
+
 #include "rtps/common/types.h"
 
 namespace rtps {

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -40,7 +40,7 @@ namespace rtps {
 namespace Config {
 const VendorId_t VENDOR_ID = {13, 37};
 const std::array<uint8_t, 4> IP_ADDRESS = {
-    192, 168, 1, 103}; // Needs to be set in lwipcfg.h too.
+    192, 168, 11, 2}; // Needs to be set in lwipcfg.h too.
 const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 
 const uint8_t DOMAIN_ID = 0; // 230 possible with UDP

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -46,11 +46,11 @@ const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
 const uint8_t NUM_STATELESS_WRITERS = 2;
 const uint8_t NUM_STATELESS_READERS = 2;
-const uint8_t NUM_STATEFUL_READERS = 2;
-const uint8_t NUM_STATEFUL_WRITERS = 2;
+const uint8_t NUM_STATEFUL_READERS = 8;
+const uint8_t NUM_STATEFUL_WRITERS = 8;
 const uint8_t MAX_NUM_PARTICIPANTS = 1;
-const uint8_t NUM_WRITERS_PER_PARTICIPANT = 4;
-const uint8_t NUM_READERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
+const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
 const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
 const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
 
@@ -63,21 +63,21 @@ const uint8_t MAX_NUM_READER_CALLBACKS = 5;
 const uint8_t HISTORY_SIZE_STATELESS = 2;
 const uint8_t HISTORY_SIZE_STATEFUL = 10;
 
-const uint8_t MAX_TYPENAME_LENGTH = 20;
-const uint8_t MAX_TOPICNAME_LENGTH = 20;
+const uint8_t MAX_TYPENAME_LENGTH = 40;
+const uint8_t MAX_TOPICNAME_LENGTH = 40;
 
-const int HEARTBEAT_STACKSIZE = 1200;          // byte
-const int THREAD_POOL_WRITER_STACKSIZE = 1100; // byte
-const int THREAD_POOL_READER_STACKSIZE = 1600; // byte
-const uint16_t SPDP_WRITER_STACKSIZE = 550;    // byte
+const int HEARTBEAT_STACKSIZE = 4096;          // byte
+const int THREAD_POOL_WRITER_STACKSIZE = 4096; // byte
+const int THREAD_POOL_READER_STACKSIZE = 4096; // byte
+const uint16_t SPDP_WRITER_STACKSIZE = 4096;    // byte
 
 const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
-const uint16_t SPDP_RESEND_PERIOD_MS = 1000;
+const uint16_t SPDP_RESEND_PERIOD_MS = 10000;
 const uint8_t SPDP_CYCLECOUNT_HEARTBEAT =
     2; // skip x SPDP rounds before checking liveliness
 const uint8_t SPDP_WRITER_PRIO = 24;
 const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
-const uint8_t SPDP_MAX_NUM_LOCATORS = 1;
+const uint8_t SPDP_MAX_NUM_LOCATORS = 5;
 const Duration_t SPDP_DEFAULT_REMOTE_LEASE_DURATION = {
     100, 0}; // Default lease duration for remote participants, usually
              // overwritten by remote info
@@ -93,7 +93,7 @@ const int THREAD_POOL_NUM_WRITERS = 1;
 const int THREAD_POOL_NUM_READERS = 1;
 const int THREAD_POOL_WRITER_PRIO = 24;
 const int THREAD_POOL_READER_PRIO = 24;
-const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 10;
+const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 20;
 
 constexpr int OVERALL_HEAP_SIZE =
     THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -31,53 +31,73 @@ namespace rtps {
 
 #define IS_LITTLE_ENDIAN 1
 
+// define only if using FreeRTOS
+#define OS_IS_FREERTOS
 
-    namespace Config {
-        const VendorId_t VENDOR_ID = {13, 37};
-        const std::array<uint8_t, 4> IP_ADDRESS = {192,168,11,2};  // Needs to be set in Src/lwip.c too.
-        const GuidPrefix_t BASE_GUID_PREFIX{1,2,3,4,5,6,7,8,9,10,12};
+namespace Config {
+const VendorId_t VENDOR_ID = {13, 37};
+const std::array<uint8_t, 4> IP_ADDRESS = {
+    192, 168, 1, 103}; // Needs to be set in lwipcfg.h too.
+const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 
-        const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
-        const uint8_t NUM_STATELESS_WRITERS = 2;
-        const uint8_t NUM_STATELESS_READERS = 2;
-        const uint8_t NUM_STATEFUL_READERS = 8;
-        const uint8_t NUM_STATEFUL_WRITERS = 8;
-        const uint8_t MAX_NUM_PARTICIPANTS = 1;
-        const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
-        const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
-        const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
-        const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
+const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
+const uint8_t NUM_STATELESS_WRITERS = 2;
+const uint8_t NUM_STATELESS_READERS = 2;
+const uint8_t NUM_STATEFUL_READERS = 2;
+const uint8_t NUM_STATEFUL_WRITERS = 2;
+const uint8_t MAX_NUM_PARTICIPANTS = 1;
+const uint8_t NUM_WRITERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_READERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
+const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
 
-        const uint8_t HISTORY_SIZE = 10;
+const uint8_t MAX_NUM_UNMATCHED_REMOTE_WRITERS = 15;
+const uint8_t MAX_NUM_UNMATCHED_REMOTE_READERS = 15;
+    
+const uint8_t MAX_NUM_READER_CALLBACKS = 5;
 
-        const uint8_t MAX_TYPENAME_LENGTH = 40;
-        const uint8_t MAX_TOPICNAME_LENGTH = 40;
 
-        const int HEARTBEAT_STACKSIZE = 4096; // byte
-        const int THREAD_POOL_WRITER_STACKSIZE = 4096; // byte
-        const int THREAD_POOL_READER_STACKSIZE = 4096; // byte
-        const uint16_t SPDP_WRITER_STACKSIZE = 4096; // byte
+const uint8_t HISTORY_SIZE_STATELESS = 2;
+const uint8_t HISTORY_SIZE_STATEFUL = 10;
 
-        const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
-        const uint16_t SPDP_RESEND_PERIOD_MS = 10000;
-        const uint8_t SPDP_WRITER_PRIO = 24;
-        const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
-        const uint8_t SPDP_MAX_NUM_LOCATORS = 5;
-        const Duration_t SPDP_LEASE_DURATION = {100, 0};
+const uint8_t MAX_TYPENAME_LENGTH = 20;
+const uint8_t MAX_TOPICNAME_LENGTH = 20;
 
-        const int MAX_NUM_UDP_CONNECTIONS = 10;
+const int HEARTBEAT_STACKSIZE = 1200;          // byte
+const int THREAD_POOL_WRITER_STACKSIZE = 1100; // byte
+const int THREAD_POOL_READER_STACKSIZE = 1600; // byte
+const uint16_t SPDP_WRITER_STACKSIZE = 550;    // byte
 
-        const int THREAD_POOL_NUM_WRITERS = 1;
-        const int THREAD_POOL_NUM_READERS = 1;
-        const int THREAD_POOL_WRITER_PRIO = 24;
-        const int THREAD_POOL_READER_PRIO = 24;
-        const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 20;
+const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
+const uint16_t SPDP_RESEND_PERIOD_MS = 1000;
+const uint8_t SPDP_CYCLECOUNT_HEARTBEAT =
+    2; // skip x SPDP rounds before checking liveliness
+const uint8_t SPDP_WRITER_PRIO = 24;
+const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
+const uint8_t SPDP_MAX_NUM_LOCATORS = 1;
+const Duration_t SPDP_DEFAULT_REMOTE_LEASE_DURATION = {
+    100, 0}; // Default lease duration for remote participants, usually
+             // overwritten by remote info
+const Duration_t SPDP_MAX_REMOTE_LEASE_DURATION = {
+    180,
+    0}; // Absolute maximum lease duration, ignoring remote participant info
 
-        constexpr int OVERALL_HEAP_SIZE = 	THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +
-											THREAD_POOL_NUM_READERS * THREAD_POOL_READER_STACKSIZE +
-											MAX_NUM_PARTICIPANTS * SPDP_WRITER_STACKSIZE +
-											NUM_STATEFUL_WRITERS * HEARTBEAT_STACKSIZE;
-    }
-}
+const Duration_t SPDP_LEASE_DURATION = {100, 0};
 
-#endif //RTPS_CONFIG_H
+const int MAX_NUM_UDP_CONNECTIONS = 10;
+
+const int THREAD_POOL_NUM_WRITERS = 1;
+const int THREAD_POOL_NUM_READERS = 1;
+const int THREAD_POOL_WRITER_PRIO = 24;
+const int THREAD_POOL_READER_PRIO = 24;
+const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 10;
+
+constexpr int OVERALL_HEAP_SIZE =
+    THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +
+    THREAD_POOL_NUM_READERS * THREAD_POOL_READER_STACKSIZE +
+    MAX_NUM_PARTICIPANTS * SPDP_WRITER_STACKSIZE +
+    NUM_STATEFUL_WRITERS * HEARTBEAT_STACKSIZE;
+} // namespace Config
+} // namespace rtps
+
+#endif // RTPS_CONFIG_H

--- a/include/rtps/conversion.h
+++ b/include/rtps/conversion.h
@@ -26,7 +26,7 @@ typedef uint32_t TickType_t;
 #define configTICK_RATE_HZ ((TickType_t)1000)
 
 #ifndef pdMS_TO_TICKS
-    #define pdMS_TO_TICKS(xTimeInMs) ((TickType_t)(((TickType_t)(xTimeInMs) * (TickType_t)configTICK_RATE_HZ) / (TickType_t)1000))
+#define pdMS_TO_TICKS(xTimeInMs) ((TickType_t)(((TickType_t)(xTimeInMs) * (TickType_t)configTICK_RATE_HZ) / (TickType_t)1000))
 #endif
 
 #define xTaskGetTickCount osKernelGetTickCount

--- a/include/rtps/conversion.h
+++ b/include/rtps/conversion.h
@@ -1,0 +1,40 @@
+/* 
+ * Conversion of FreeRTOS's definitions/types/functions in embeddedRTPS
+ * Copyright (c) 2021 smorita_emb
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RTPS_CONVERSION_H
+#define RTPS_CONVERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdint.h>
+typedef uint32_t TickType_t;
+#define configTICK_RATE_HZ ((TickType_t)1000)
+
+#ifndef pdMS_TO_TICKS
+    #define pdMS_TO_TICKS(xTimeInMs) ((TickType_t)(((TickType_t)(xTimeInMs) * (TickType_t)configTICK_RATE_HZ) / (TickType_t)1000))
+#endif
+
+#define xTaskGetTickCount osKernelGetTickCount
+#define vTaskDelay osDelay
+
+void sys_msleep(unsigned int ms);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTPS_CONVERSION_H */

--- a/mros2.lib
+++ b/mros2.lib
@@ -1,1 +1,1 @@
-https://github.com/mROS-base/mros2#v0.3.2
+https://github.com/mROS-base/mros2#mros2_track-ertps-1410a87


### PR DESCRIPTION
The latest version of embeddedRTPS-STM32 now tracks [embeddedRTPS @ 1410a87](https://github.com/embedded-software-laboratory/embeddedRTPS/tree/1410a8776660244249a84031ffa78c9bdaa45e19) in it.
https://github.com/embedded-software-laboratory/embeddedRTPS-STM32/tree/master/stm32/Middlewares/Third_Party

This PR allows mros2 to follow the above version of embeddedRTPS.
Previously in mros2, we need to modify the source code of embeddedRTPS from the original (published by embedded-software-laboratory) to combine with mros2. But we found that the original source code could be used as is by modifying the implementation in mros2. We plan to keep this policy in future updates.
https://github.com/mROS-base/mros2/tree/mros2_track-ertps-1410a87

As far as I've confirmed so far, the first attempt to communicate with the ROS2 node on the host is successful; but the second and subsequent attempts to reconnect have not been successful. This issue often occurred in the previous mros2 implementation. 
The bigger problem is that multicast communication, which is the most important contribution of the embeddedRTPS update, has not been confirmed. I guess these causes may be on ROS 2 side. This is likely because even a simple public node for a single topic generates multiple accompanying topics in the system.
Although there are some issues mentioned above, I would like to suggest that this PR is worthy to merge. We will then proceed to investigate and resolve these issues.

---
@s-hosoai Could you check this PR by all example apps onto both F767ZI and H743ZI2? I only checked echoreply_string  onto F767ZI
@smoriemb Could you confirm this PR with your environment? Any question, comments and information are very welcome!!