### PR TITLE
add Humble as the supported host environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 # mros2-mbed
 
 mROS 2 (formally `mros2`) realizes a agent-less and lightweight runtime environment compatible with ROS 2 for embedded devices.
-mROS 2 mainly offers pub/sub APIs compatible with [rclcpp](https://docs.ros2.org/foxy/api/rclcpp/index.html) for embedded devices.
+mROS 2 mainly offers pub/sub APIs compatible with [rclcpp](https://docs.ros.org/en/rolling/p/rclcpp/index.html) for embedded devices.
 
 mROS 2 consists of communication library for pub/sub APIs, RTPS protocol, UDP/IP stack, and real-time kernel.
 This repository provides the reference implementation of mROS 2 that can be operated on the Mbed enabled board.
@@ -14,19 +14,19 @@ Please also check [mros2 repository](https://github.com/mROS-base/mros2) for mor
 - Mbed device
   - Board: Mbed enabled boards having an Ethernet port  
     - For now, these boards below are confirmed to run the example on them.
-      - [STM32 NUCLEO-F429ZI](https://www.st.com/en/evaluation-tools/nucleo-f429zi.html)
       - [STM32 NUCLEO-F767ZI](https://www.st.com/en/evaluation-tools/nucleo-f767zi.html)
-      - [Seeed Arch Max V1.1](https://wiki.seeedstudio.com/Arch_Max_v1.1/)
-    - These boards below are also confirmed but not always supported in the latest version (due to our development resources,,,) 
       - [STM32 NUCLEO-H743ZI2](https://www.st.com/en/evaluation-tools/nucleo-h743zi.html)
+    - These boards below are also confirmed but not always supported in the latest version (due to our development resources,,,) 
+      - [STM32 NUCLEO-F429ZI](https://www.st.com/en/evaluation-tools/nucleo-f429zi.html)
       - [STM32 F746NG-Discovery](https://www.st.com/ja/evaluation-tools/32f746gdiscovery.html)
       - [STM32 F769NI-Discovery](https://www.st.com/ja/evaluation-tools/32f769idiscovery.html)
+      - [Seeed Arch Max V1.1](https://wiki.seeedstudio.com/Arch_Max_v1.1/)
       - [RENESAS GR-MANGO](https://www.renesas.com/products/gadget-renesas/boards/gr-mango)
   - Kernel: [Mbed OS 6](https://github.com/ARMmbed/mbed-os)
   - check the Mbed website for [the boards list](https://os.mbed.com/platforms/?q=&Mbed+OS+6=Bare+metal&Mbed+OS+6=RTOS&Communication=Ethernet) where mros2 may work. Please let us know if you find a new board that can work as mros2 enabled device.
 - Host environment
+  - [ROS 2 Humble Hawksbill](https://docs.ros.org/en/humble/index.html) on Ubuntu 22.04 LTS
   - [ROS 2 Foxy Fitzroy](https://docs.ros.org/en/foxy/index.html) on Ubuntu 20.04 LTS
-  - [ROS 2 Dashing Diademata](https://docs.ros.org/en/dashing/index.html) on Ubuntu 18.04 LTS
 - Network setting
   - Make sure both the device and the host are connected to the wired network with the following setting, since they are statically configured to the board (if you want to change them, please edit both `app.cpp` and `include/rtps/config.h`).
     - IP address: 192.168.11.x
@@ -50,12 +50,12 @@ cd mros2-mbed
 # +-------------------+----------------+
 # | Your target board | [TARGET]       |
 # +-------------------+----------------+
-# | NUCLEO-F429ZI     | NUCLEO_F429ZI  |
 # | NUCLEO-F767ZI     | NUCLEO_F767ZI  |
-# | Arch Max v1.1     | ARCH_MAX       |
 # | NUCLEO-H743ZI2    | NUCLEO_H743ZI2 |
+# | NUCLEO-F429ZI     | NUCLEO_F429ZI  |
 # | F746NG-Discovery  | DISCO_F746NG   |
 # | F769NI-Discovery  | DISCO_F769NI   |
+# | Arch Max v1.1     | ARCH_MAX       |
 # | GR-MANGO          | GR_MANGO       |
 # +-------------------+----------------+
 ./build.bash all [TARGET] echoreply_string
@@ -82,8 +82,8 @@ ready to pub/sub message
 ```
 6. On the PC console, type the command below.
 ```
-docker run --rm -it --net=host ros:foxy /bin/bash \
-  -c "source /opt/ros/foxy/setup.bash &&
+docker run --rm -it --net=host ros:humble /bin/bash \
+  -c "source /opt/ros/humble/setup.bash &&
   cd &&
   git clone https://github.com/mROS-base/mros2-host-examples &&
   cd mros2-host-examples &&
@@ -175,14 +175,14 @@ Of course you can also create a new program file and specify it as your own appl
 ### mturtle_teleop
 
 - Description:
-  - This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/foxy-devel/turtlesim) (mros2 dedicated version of turtlesim).
+  - This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/humble-devel/turtlesim) (mros2 dedicated version of turtlesim).
   - The mROS 2 node on the embedded board publishes `Twist` (`geometry_msgs::msg::Twist`) message to `/turtle1/cmd_vel` topic, according to the input from keyboard via serial console.
 - Please see [mturtle_teleop/README.md](workspace/mturtle_teleop/README.md) for more detail including host operation.
 
 ### mturtle_teleop_joy
 
 - Description:
-  - This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/foxy-devel/turtlesim) (mros2 dedicated version of turtlesim).
+  - This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/humble-devel/turtlesim) (mros2 dedicated version of turtlesim).
   - The mROS 2 node on the embedded board publishes `Twist` (`geometry_msgs::msg::Twist`) message to `/turtle1/cmd_vel` topic, according to the input from Joystick module.
 - Please see [mturtle_teleop_joy/README.md](workspace/mturtle_teleop_joy/README.md) for more detail including host operation.
 

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -25,6 +25,9 @@ Author: i11 - Embedded Software, RWTH Aachen University
 #ifndef RTPS_CONFIG_H
 #define RTPS_CONFIG_H
 
+/* added for mROS 2 */
+#include "conversion.h"
+
 #include "rtps/common/types.h"
 
 namespace rtps {

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -40,7 +40,7 @@ namespace rtps {
 namespace Config {
 const VendorId_t VENDOR_ID = {13, 37};
 const std::array<uint8_t, 4> IP_ADDRESS = {
-    192, 168, 1, 103}; // Needs to be set in lwipcfg.h too.
+    192, 168, 11, 2}; // Needs to be set in lwipcfg.h too.
 const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 
 const uint8_t DOMAIN_ID = 0; // 230 possible with UDP

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -46,11 +46,11 @@ const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
 const uint8_t NUM_STATELESS_WRITERS = 2;
 const uint8_t NUM_STATELESS_READERS = 2;
-const uint8_t NUM_STATEFUL_READERS = 2;
-const uint8_t NUM_STATEFUL_WRITERS = 2;
+const uint8_t NUM_STATEFUL_READERS = 8;
+const uint8_t NUM_STATEFUL_WRITERS = 8;
 const uint8_t MAX_NUM_PARTICIPANTS = 1;
-const uint8_t NUM_WRITERS_PER_PARTICIPANT = 4;
-const uint8_t NUM_READERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
+const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
 const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
 const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
 
@@ -63,21 +63,21 @@ const uint8_t MAX_NUM_READER_CALLBACKS = 5;
 const uint8_t HISTORY_SIZE_STATELESS = 2;
 const uint8_t HISTORY_SIZE_STATEFUL = 10;
 
-const uint8_t MAX_TYPENAME_LENGTH = 20;
-const uint8_t MAX_TOPICNAME_LENGTH = 20;
+const uint8_t MAX_TYPENAME_LENGTH = 40;
+const uint8_t MAX_TOPICNAME_LENGTH = 40;
 
-const int HEARTBEAT_STACKSIZE = 1200;          // byte
-const int THREAD_POOL_WRITER_STACKSIZE = 1100; // byte
-const int THREAD_POOL_READER_STACKSIZE = 1600; // byte
-const uint16_t SPDP_WRITER_STACKSIZE = 550;    // byte
+const int HEARTBEAT_STACKSIZE = 4096;          // byte
+const int THREAD_POOL_WRITER_STACKSIZE = 4096; // byte
+const int THREAD_POOL_READER_STACKSIZE = 4096; // byte
+const uint16_t SPDP_WRITER_STACKSIZE = 4096;    // byte
 
 const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
-const uint16_t SPDP_RESEND_PERIOD_MS = 1000;
+const uint16_t SPDP_RESEND_PERIOD_MS = 10000;
 const uint8_t SPDP_CYCLECOUNT_HEARTBEAT =
     2; // skip x SPDP rounds before checking liveliness
 const uint8_t SPDP_WRITER_PRIO = 24;
 const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
-const uint8_t SPDP_MAX_NUM_LOCATORS = 1;
+const uint8_t SPDP_MAX_NUM_LOCATORS = 5;
 const Duration_t SPDP_DEFAULT_REMOTE_LEASE_DURATION = {
     100, 0}; // Default lease duration for remote participants, usually
              // overwritten by remote info
@@ -93,7 +93,7 @@ const int THREAD_POOL_NUM_WRITERS = 1;
 const int THREAD_POOL_NUM_READERS = 1;
 const int THREAD_POOL_WRITER_PRIO = 24;
 const int THREAD_POOL_READER_PRIO = 24;
-const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 10;
+const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 20;
 
 constexpr int OVERALL_HEAP_SIZE =
     THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -31,53 +31,73 @@ namespace rtps {
 
 #define IS_LITTLE_ENDIAN 1
 
+// define only if using FreeRTOS
+#define OS_IS_FREERTOS
 
-    namespace Config {
-        const VendorId_t VENDOR_ID = {13, 37};
-        const std::array<uint8_t, 4> IP_ADDRESS = {192,168,11,2};  // Needs to be set in Src/lwip.c too.
-        const GuidPrefix_t BASE_GUID_PREFIX{1,2,3,4,5,6,7,8,9,10,12};
+namespace Config {
+const VendorId_t VENDOR_ID = {13, 37};
+const std::array<uint8_t, 4> IP_ADDRESS = {
+    192, 168, 1, 103}; // Needs to be set in lwipcfg.h too.
+const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 
-        const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
-        const uint8_t NUM_STATELESS_WRITERS = 2;
-        const uint8_t NUM_STATELESS_READERS = 2;
-        const uint8_t NUM_STATEFUL_READERS = 8;
-        const uint8_t NUM_STATEFUL_WRITERS = 8;
-        const uint8_t MAX_NUM_PARTICIPANTS = 1;
-        const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
-        const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
-        const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
-        const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
+const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
+const uint8_t NUM_STATELESS_WRITERS = 2;
+const uint8_t NUM_STATELESS_READERS = 2;
+const uint8_t NUM_STATEFUL_READERS = 2;
+const uint8_t NUM_STATEFUL_WRITERS = 2;
+const uint8_t MAX_NUM_PARTICIPANTS = 1;
+const uint8_t NUM_WRITERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_READERS_PER_PARTICIPANT = 4;
+const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
+const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
 
-        const uint8_t HISTORY_SIZE = 10;
+const uint8_t MAX_NUM_UNMATCHED_REMOTE_WRITERS = 15;
+const uint8_t MAX_NUM_UNMATCHED_REMOTE_READERS = 15;
+    
+const uint8_t MAX_NUM_READER_CALLBACKS = 5;
 
-        const uint8_t MAX_TYPENAME_LENGTH = 40;
-        const uint8_t MAX_TOPICNAME_LENGTH = 40;
 
-        const int HEARTBEAT_STACKSIZE = 4096; // byte
-        const int THREAD_POOL_WRITER_STACKSIZE = 4096; // byte
-        const int THREAD_POOL_READER_STACKSIZE = 4096; // byte
-        const uint16_t SPDP_WRITER_STACKSIZE = 4096; // byte
+const uint8_t HISTORY_SIZE_STATELESS = 2;
+const uint8_t HISTORY_SIZE_STATEFUL = 10;
 
-        const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
-        const uint16_t SPDP_RESEND_PERIOD_MS = 10000;
-        const uint8_t SPDP_WRITER_PRIO = 24;
-        const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
-        const uint8_t SPDP_MAX_NUM_LOCATORS = 5;
-        const Duration_t SPDP_LEASE_DURATION = {100, 0};
+const uint8_t MAX_TYPENAME_LENGTH = 20;
+const uint8_t MAX_TOPICNAME_LENGTH = 20;
 
-        const int MAX_NUM_UDP_CONNECTIONS = 10;
+const int HEARTBEAT_STACKSIZE = 1200;          // byte
+const int THREAD_POOL_WRITER_STACKSIZE = 1100; // byte
+const int THREAD_POOL_READER_STACKSIZE = 1600; // byte
+const uint16_t SPDP_WRITER_STACKSIZE = 550;    // byte
 
-        const int THREAD_POOL_NUM_WRITERS = 1;
-        const int THREAD_POOL_NUM_READERS = 1;
-        const int THREAD_POOL_WRITER_PRIO = 24;
-        const int THREAD_POOL_READER_PRIO = 24;
-        const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 20;
+const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
+const uint16_t SPDP_RESEND_PERIOD_MS = 1000;
+const uint8_t SPDP_CYCLECOUNT_HEARTBEAT =
+    2; // skip x SPDP rounds before checking liveliness
+const uint8_t SPDP_WRITER_PRIO = 24;
+const uint8_t SPDP_MAX_NUMBER_FOUND_PARTICIPANTS = 5;
+const uint8_t SPDP_MAX_NUM_LOCATORS = 1;
+const Duration_t SPDP_DEFAULT_REMOTE_LEASE_DURATION = {
+    100, 0}; // Default lease duration for remote participants, usually
+             // overwritten by remote info
+const Duration_t SPDP_MAX_REMOTE_LEASE_DURATION = {
+    180,
+    0}; // Absolute maximum lease duration, ignoring remote participant info
 
-        constexpr int OVERALL_HEAP_SIZE = 	THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +
-											THREAD_POOL_NUM_READERS * THREAD_POOL_READER_STACKSIZE +
-											MAX_NUM_PARTICIPANTS * SPDP_WRITER_STACKSIZE +
-											NUM_STATEFUL_WRITERS * HEARTBEAT_STACKSIZE;
-    }
-}
+const Duration_t SPDP_LEASE_DURATION = {100, 0};
 
-#endif //RTPS_CONFIG_H
+const int MAX_NUM_UDP_CONNECTIONS = 10;
+
+const int THREAD_POOL_NUM_WRITERS = 1;
+const int THREAD_POOL_NUM_READERS = 1;
+const int THREAD_POOL_WRITER_PRIO = 24;
+const int THREAD_POOL_READER_PRIO = 24;
+const int THREAD_POOL_WORKLOAD_QUEUE_LENGTH = 10;
+
+constexpr int OVERALL_HEAP_SIZE =
+    THREAD_POOL_NUM_WRITERS * THREAD_POOL_WRITER_STACKSIZE +
+    THREAD_POOL_NUM_READERS * THREAD_POOL_READER_STACKSIZE +
+    MAX_NUM_PARTICIPANTS * SPDP_WRITER_STACKSIZE +
+    NUM_STATEFUL_WRITERS * HEARTBEAT_STACKSIZE;
+} // namespace Config
+} // namespace rtps
+
+#endif // RTPS_CONFIG_H

--- a/include/rtps/conversion.h
+++ b/include/rtps/conversion.h
@@ -1,0 +1,40 @@
+/* 
+ * Conversion of FreeRTOS's definitions/types/functions in embeddedRTPS
+ * Copyright (c) 2021 smorita_emb
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#ifndef RTPS_CONVERSION_H
+#define RTPS_CONVERSION_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#include <stdint.h>
+typedef uint32_t TickType_t;
+#define configTICK_RATE_HZ ((TickType_t)1000)
+
+#ifndef pdMS_TO_TICKS
+    #define pdMS_TO_TICKS(xTimeInMs) ((TickType_t)(((TickType_t)(xTimeInMs) * (TickType_t)configTICK_RATE_HZ) / (TickType_t)1000))
+#endif
+
+#define xTaskGetTickCount osKernelGetTickCount
+#define vTaskDelay osDelay
+
+void sys_msleep(unsigned int ms);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RTPS_CONVERSION_H */

--- a/mros2.lib
+++ b/mros2.lib
@@ -1,1 +1,1 @@
-https://github.com/mROS-base/mros2#v0.3.2
+https://github.com/mROS-base/mros2#mros2_track-ertps-1410a87

--- a/workspace/mturtle_teleop/README.md
+++ b/workspace/mturtle_teleop/README.md
@@ -1,6 +1,6 @@
 # mturtle_teleop
 
-This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/foxy-devel/turtlesim) (mros2 dedicated version of turtlesim).
+This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/humble-devel/turtlesim) (mros2 dedicated version of turtlesim).
 
 The mROS 2 node on the embedded board publishes `Twist` (`geometry_msgs::msg::Twist`) message to `/turtle1/cmd_vel` topic, according to the input from keyboard via serial console.
 The feature is almost the same as [ros2/teleop_twist_keyboard](https://github.com/ros2/teleop_twist_keyboard).
@@ -32,7 +32,8 @@ Since the current version of does not support the QoS control, the original vers
 
 ```
 $ cd <your_ros2_ws>/src
-$ git clone -b mros2/foxy-devel https://github.com/mROS-base/ros_tutorials
+# When you use Foxy as the host, please change the branch to `mros2/foxy-devel`
+$ git clone -b mros2/humble-devel https://github.com/mROS-base/ros_tutorials
 $ cd ..
 $ colcon build --packages-select mturtlesim
 $ source install/local_setup.bash

--- a/workspace/mturtle_teleop_joy/README.md
+++ b/workspace/mturtle_teleop_joy/README.md
@@ -1,6 +1,6 @@
 # mturtle_teleop_joy
 
-This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/foxy-devel/turtlesim) (mros2 dedicated version of turtlesim).
+This is a sample application along with [mturtlesim](https://github.com/mROS-base/ros_tutorials/tree/mros2/humble-devel/turtlesim) (mros2 dedicated version of turtlesim).
 
 The mROS 2 node on the embedded board publishes `Twist` (`geometry_msgs::msg::Twist`) message to `/turtle1/cmd_vel` topic, according to the input from Joystick module.
 You can also enter the console mode to hit (w|x|a|d|s) key.
@@ -43,7 +43,8 @@ Since the current version of does not support the QoS control, the original vers
 
 ```
 $ cd <your_ros2_ws>/src
-$ git clone -b mros2/foxy-devel https://github.com/mROS-base/ros_tutorials
+# When you use Foxy as the host, please change the branch to `mros2/foxy-devel`
+$ git clone -b mros2/humble-devel https://github.com/mROS-base/ros_tutorials
 $ cd ..
 $ colcon build --packages-select mturtlesim
 $ source install/local_setup.bash


### PR DESCRIPTION
I've confirmed the latest mros2-mbed (with #24) could work fine with Humble as the host device. So this PR adds Humble as the supported environment. I will merge this PR after merging #24 (and checking by @s-hosoai).

@s-hosoai Please also check on your environment. Note that `mturtlesim` on the host should change its branch to `mros2/humble-devel`.
https://github.com/mROS-base/ros_tutorials/tree/mros2/humble-devel