### PR TITLE
Enlarge parameter for NUM_WRITERS/READERS

### DIFF
--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -72,7 +72,7 @@ const int THREAD_POOL_READER_STACKSIZE = 4096; // byte
 const uint16_t SPDP_WRITER_STACKSIZE = 4096;    // byte
 
 const uint16_t SF_WRITER_HB_PERIOD_MS = 4000;
-const uint16_t SPDP_RESEND_PERIOD_MS = 10000;
+const uint16_t SPDP_RESEND_PERIOD_MS = 1000;
 const uint8_t SPDP_CYCLECOUNT_HEARTBEAT =
     2; // skip x SPDP rounds before checking liveliness
 const uint8_t SPDP_WRITER_PRIO = 24;

--- a/include/rtps/config.h
+++ b/include/rtps/config.h
@@ -44,15 +44,15 @@ const std::array<uint8_t, 4> IP_ADDRESS = {
 const GuidPrefix_t BASE_GUID_PREFIX{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 12};
 
 const uint8_t DOMAIN_ID = 0; // 230 possible with UDP
-const uint8_t NUM_STATELESS_WRITERS = 2;
-const uint8_t NUM_STATELESS_READERS = 2;
+const uint8_t NUM_STATELESS_WRITERS = 4;
+const uint8_t NUM_STATELESS_READERS = 4;
 const uint8_t NUM_STATEFUL_READERS = 8;
 const uint8_t NUM_STATEFUL_WRITERS = 8;
 const uint8_t MAX_NUM_PARTICIPANTS = 1;
 const uint8_t NUM_WRITERS_PER_PARTICIPANT = 16;
 const uint8_t NUM_READERS_PER_PARTICIPANT = 16;
-const uint8_t NUM_WRITER_PROXIES_PER_READER = 3;
-const uint8_t NUM_READER_PROXIES_PER_WRITER = 3;
+const uint8_t NUM_WRITER_PROXIES_PER_READER = 6;
+const uint8_t NUM_READER_PROXIES_PER_WRITER = 6;
 
 const uint8_t MAX_NUM_UNMATCHED_REMOTE_WRITERS = 15;
 const uint8_t MAX_NUM_UNMATCHED_REMOTE_READERS = 15;


### PR DESCRIPTION
This PR is expected to fix #26 an #27 

Here is the list I've tried out. "env" means how to install/prepare the ROS 2 environment.

| cpu | distro | env | #26 | #27 | note |
| ---- | ---- | ---- | ---- | ---- | ---- |
| x64 | Foxy | native | fixed | fixed | OK!! |
| x64 | Foxy | docker | fixed | fixed | OK!! |
| x64 | Humble | native |  |  | not prepared and tried yet |
| x64 | Humble | docker | fixed | fixed | OK!! |
| arm64 | Foxy | native | fixed | fixed | OK!! |
| arm64 | Foxy | docker | fixed | fixed | OK!! |
| arm64 | Humble | native | fixed | no,,, | Fault occurred |
| arm64 | Humble | docker | fixed | fixed | OK!! |

We can conclude arm64/Humble/native may be a rare case and it is not reasonable to fix this situation.

Note that this commit increases binary size.
@smoriemb is it acceptable for your env/board?
```
-- built: /var/mbed/cmake_build/NUCLEO_F767ZI/develop/GCC_ARM/mros2-mbed.bin
-- built: /var/mbed/cmake_build/NUCLEO_F767ZI/develop/GCC_ARM/mros2-mbed.hex
| Module                     |      .text |    .data |         .bss |
|----------------------------|------------|----------|--------------|
| [fill]                     |    340(-2) |   12(+0) |       61(+0) |
| [lib]/c.a                  |   9288(+0) | 2108(+0) |       58(+0) |
| [lib]/gcc.a                |   6752(+0) |    0(+0) |        0(+0) |
| [lib]/misc                 |    188(+0) |    4(+0) |       28(+0) |
| [lib]/nosys.a              |     32(+0) |    0(+0) |        0(+0) |
| [lib]/stdc++.a             |   5628(+0) |    8(+0) |       44(+0) |
| mbed-os/cmsis              |   9974(+0) |  168(+0) |    10304(+0) |
| mbed-os/connectivity       |  52754(+0) |  103(+0) |    32671(+0) |
| mbed-os/drivers            |    294(+0) |    0(+0) |        0(+0) |
| mbed-os/events             |   1544(+0) |    0(+0) |     3104(+0) |
| mbed-os/hal                |   1568(+0) |    8(+0) |      114(+0) |
| mbed-os/platform           |   6600(+0) |  260(+0) |      381(+0) |
| mbed-os/rtos               |   1280(+0) |    0(+0) |        8(+0) |
| mbed-os/targets            |  14070(+0) |    9(+0) |     1316(+0) |
| mros2/embeddedRTPS         |  20268(+2) |    0(+0) |        0(+0) |
| mros2/src                  |   1196(+0) |    0(+0) | 22155(+5640) |
| workspace/echoreply_string |    924(+0) |    0(+0) |       52(+0) |
| Subtotals                  | 132700(+0) | 2680(+0) | 70296(+5640) |
Total Static RAM memory (data + bss): 72976(+5640) bytes
Total Flash memory (text + data): 135380(+0) bytes
```

---

And also, this PR includes restoring `SPDP_RESEND_PERIOD_MS` according to [embeddedRTPS-STM32](https://github.com/embedded-software-laboratory/embeddedRTPS-STM32/blob/master/stm32/Core/Inc/rtps/config.h#L72). I don't remember why I need to enlarge this parameter, but this modification does not affect the behavior so much.
