### PR TITLE
implement echoback_string sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,15 @@ Please also check [mROS-base/mros2-host-examples](https://github.com/mROS-base/m
 You can switch the example by specifying the third argument of `build.bash`.
 Of course you can also create a new program file and specify it as your own application.
 
+### echoback_string
+
+- Description:
+  - The mROS 2 node on the embedded board publishes `string` (`std_msgs::msg::String`) message to `/to_linux` topic.
+  - (The node on the host will echoreply this message as it is.)
+  - The mROS 2 node subscribes the replied message from `/to_stm` topic.
+- Host operation:
+  - `$ ros2 run mros2_echoreply_string echoreply_node`
+
 ### echoreply_string (default)
 
 - Description:

--- a/workspace/echoback_string/app.cpp
+++ b/workspace/echoback_string/app.cpp
@@ -24,9 +24,6 @@
 #define DEFAULT_GATEWAY ("192.168.11.1") /* Default gateway */
 
 
-mros2::Subscriber sub;
-mros2::Publisher pub;
-
 void userCallback(std_msgs::msg::String *msg)
 {
   printf("subscribed msg: '%s'\r\n", msg->data.c_str());
@@ -44,21 +41,21 @@ int main() {
   MROS2_DEBUG("mROS 2 initialization is completed\r\n");
 
   mros2::Node node = mros2::Node::create_node("mros2_node");
-  pub = node.create_publisher<std_msgs::msg::String>("to_linux", 10);
-  sub = node.create_subscription<std_msgs::msg::String>("to_stm", 10, userCallback);
+  mros2::Publisher pub = node.create_publisher<std_msgs::msg::String>("to_linux", 10);
+  mros2::Subscriber sub = node.create_subscription<std_msgs::msg::String>("to_stm", 10, userCallback);
 
   osDelay(100);
   MROS2_INFO("ready to pub/sub message\r\n");
 
-  int32_t count = 0;
-  auto msg = std_msgs::msg::String();
-
+  auto count = 0;
   while (1) {
+    auto msg = std_msgs::msg::String();
     msg.data = "Hello, world! " + std::to_string(count++);
     printf("publishing msg: '%s'\r\n", msg.data.c_str());
     pub.publish(msg);
     osDelay(1000);
   }
+
   mros2::spin();
   return 0;
 }

--- a/workspace/echoback_string/app.cpp
+++ b/workspace/echoback_string/app.cpp
@@ -23,6 +23,10 @@
 #define SUBNET_MASK ("255.255.255.0") /* Subnet mask */
 #define DEFAULT_GATEWAY ("192.168.11.1") /* Default gateway */
 
+/* convert TARGET_NAME to put into message */
+#define quote(x) std::string(q(x))
+#define q(x) #x
+
 
 void userCallback(std_msgs::msg::String *msg)
 {
@@ -50,7 +54,7 @@ int main() {
   auto count = 0;
   while (1) {
     auto msg = std_msgs::msg::String();
-    msg.data = "Hello, world! " + std::to_string(count++);
+    msg.data = "Hello from mros2-mbed onto " + quote(TARGET_NAME) + ": " + std::to_string(count++);
     printf("publishing msg: '%s'\r\n", msg.data.c_str());
     pub.publish(msg);
     osDelay(1000);

--- a/workspace/echoback_string/app.cpp
+++ b/workspace/echoback_string/app.cpp
@@ -1,0 +1,64 @@
+/* mros2 example
+ * Copyright (c) 2022 mROS-base
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+#include "mbed.h"
+#include "mros2.h"
+#include "std_msgs/msg/string.hpp"
+#include "EthernetInterface.h"
+
+#define IP_ADDRESS ("192.168.11.2") /* IP address */
+#define SUBNET_MASK ("255.255.255.0") /* Subnet mask */
+#define DEFAULT_GATEWAY ("192.168.11.1") /* Default gateway */
+
+
+mros2::Subscriber sub;
+mros2::Publisher pub;
+
+void userCallback(std_msgs::msg::String *msg)
+{
+  printf("subscribed msg: '%s'\r\n", msg->data.c_str());
+}
+
+int main() {
+  EthernetInterface network;
+  network.set_dhcp(false);
+  network.set_network(IP_ADDRESS, SUBNET_MASK, DEFAULT_GATEWAY);
+  nsapi_size_or_error_t result = network.connect();
+
+  printf("mbed mros2 start!\r\n");
+  printf("app name: echoback_string\r\n");
+  mros2::init(0, NULL);
+  MROS2_DEBUG("mROS 2 initialization is completed\r\n");
+
+  mros2::Node node = mros2::Node::create_node("mros2_node");
+  pub = node.create_publisher<std_msgs::msg::String>("to_linux", 10);
+  sub = node.create_subscription<std_msgs::msg::String>("to_stm", 10, userCallback);
+
+  osDelay(100);
+  MROS2_INFO("ready to pub/sub message\r\n");
+
+  int32_t count = 0;
+  auto msg = std_msgs::msg::String();
+
+  while (1) {
+    msg.data = "Hello, world! " + std::to_string(count++);
+    printf("publishing msg: '%s'\r\n", msg.data.c_str());
+    pub.publish(msg);
+    osDelay(1000);
+  }
+  mros2::spin();
+  return 0;
+}

--- a/workspace/echoback_string/templates.hpp
+++ b/workspace/echoback_string/templates.hpp
@@ -1,0 +1,11 @@
+
+#include "std_msgs/msg/string.hpp"
+
+
+template mros2::Publisher mros2::Node::create_publisher<std_msgs::msg::String>(std::string topic_name, int qos);
+template void mros2::Publisher::publish(std_msgs::msg::String &msg);
+
+
+
+template mros2::Subscriber mros2::Node::create_subscription(std::string topic_name, int qos, void (*fp)(std_msgs::msg::String*));
+template void mros2::Subscriber::callback_handler<std_msgs::msg::String>(void *callee, const rtps::ReaderCacheChange &cacheChange);


### PR DESCRIPTION
This PR adds the new sample `echoback_string`.
I think this app is easy to treat, I plan to set this app as the default before releasing mros2 v0.4.0.

Please try it out!! @s-hosoai @smoriemb 

- Description:
  - The mROS 2 node on the embedded board publishes `string` (`std_msgs::msg::String`) message to `/to_linux` topic.
  - (The node on the host will echoreply this message as it is.)
  - The mROS 2 node subscribes the replied message from `/to_stm` topic.

Procedure:
- mros2-mbed (NUCLEO_F767ZI as the example board)
```
cd mros2-mbed
git checkout echoback_string
git pull
./build.bash all NUCLEO_F767ZI echoback_string
cp cmake_build/NUCLEO_F767ZI/develop/GCC_ARM/mros2-mbed.bin /media/${USER}/NODE_F767ZI/
```

- host
```
cd <dir_to_mros2_host_examples>
git clone
cd <dir_to_ros2_ws>
source /opt/ros/humble/setup.bash
colcon build --packages-select mros2_echoreply_string
source install/local_setup.bash
ros2 run mros2-echoreply_string echoreply_node
```

- serial output on the board
```
mbed mros2 start!                                                               
app name: echoback_string                                                       
[MROS2LIB] mros2_init task start                                                
mROS 2 initialization is completed                                              
                                                                                
[MROS2LIB] create_node                                                          
[MROS2LIB] start creating participant                                           
[MROS2LIB] successfully created participant                                     
[MROS2LIB] create_publisher complete.                                           
[MROS2LIB] create_subscription complete. data memory address=0x20016c50         
[MROS2LIB] Initilizing Domain complete                                          
ready to pub/sub message                                                        
                                                                                
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 0'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 1'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 2'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 3'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 4'                   
[MROS2LIB] subscriber matched with remote publisher                             
[MROS2LIB] publisher matched with remote subscriber                             
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 5'                   
subscribed msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 5'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 6'                   
subscribed msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 6'                   
publishing msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 7'                   
subscribed msg: 'Hello from mros2-mbed onto NUCLEO_F767ZI: 7'   
```