### PR TITLE
enlarget MAX_TYPENAME_LENGTH

### DIFF
--- a/platform/rtps/config.h
+++ b/platform/rtps/config.h
@@ -65,7 +65,7 @@ const uint8_t MAX_NUM_READER_CALLBACKS = 5;
 const uint8_t HISTORY_SIZE_STATELESS = 2;
 const uint8_t HISTORY_SIZE_STATEFUL = 10;
 
-const uint8_t MAX_TYPENAME_LENGTH = 40;
+const uint8_t MAX_TYPENAME_LENGTH = 60;
 const uint8_t MAX_TOPICNAME_LENGTH = 40;
 
 const int HEARTBEAT_STACKSIZE = 4096;          // byte


### PR DESCRIPTION
In the current implementation, the maximum length of type name (`MAX_TYPENAME_LENGTH`) is set to 40 in `platform/rtps/config.h`. This is used in embeddedRTPS to ensure the minimization of binary size. However, when the length we want to use in the app exceeds this value, an error occurs that is difficult to understand for the user (in fact, nullptr is returned when creating reader/writer in embeddedRTPS). Note that an identifier recognizable in the DDS space will be added to the topic name that was defined by users. For example, 8 characters are added to the 19-character `std_msgs/msg/string` to become the 27-character `std_msgs::msg::dds_::string`.

I checked [common_interfaces](https://github.com/ros2/common_interfaces), which are commonly handled in ROS 2, revealed that the topic names with the greatest length may be `visualization_msgs/msg/InteractiveMarkerFeedback` and `trajectory_msgs/msg/MultiDOFJointTrajectoryPoint` (these are 57 characters together with identifier). Therefore, I decided to set `MAX_TYPENAME_LENGTH` to 60.

One side effect is a larger binary size, but we consider it may be acceptable.

```
| Module                          |       .text |    .data |        .bss |
|---------------------------------|-------------|----------|-------------|
| [fill]                          |    354(+50) |   14(+0) |      61(+0) |
| [lib]/c.a                       |   30568(+0) | 2474(+0) |      58(+0) |
| [lib]/gcc.a                     |    7336(+0) |    0(+0) |       0(+0) |
| [lib]/misc                      |     188(+0) |    4(+0) |      28(+0) |
| [lib]/nosys.a                   |      32(+0) |    0(+0) |       0(+0) |
| [lib]/stdc++.a                  |    6972(+0) |    8(+0) |      44(+0) |
| mbed-os/cmsis                   |    9974(+0) |  168(+0) |   10304(+0) |
| mbed-os/connectivity            |   52756(+0) |  103(+0) |   32671(+0) |
| mbed-os/drivers                 |     294(+0) |    0(+0) |       0(+0) |
| mbed-os/events                  |    1544(+0) |    0(+0) |    3104(+0) |
| mbed-os/hal                     |    1568(+0) |    8(+0) |     114(+0) |
| mbed-os/platform                |    6608(+0) |  260(+0) |     381(+0) |
| mbed-os/rtos                    |    1244(+0) |    0(+0) |       8(+0) |
| mbed-os/targets                 |   14102(+0) |    9(+0) |    1316(+0) |
| mros2/embeddedRTPS              |  21106(+14) |    0(+0) |       0(+0) |
| mros2/src                       |    1552(+0) |    0(+0) | 24703(+480) |
| platform/mros2-platform.cpp.obj |     532(+0) |    0(+0) |       0(+0) |
| workspace/echoback_string       |     914(+0) |    0(+0) |       0(+0) |
| Subtotals                       | 157644(+64) | 3048(+0) | 72792(+480) |
Total Static RAM memory (data + bss): 75840(+480) bytes
Total Flash memory (text + data): 160692(+64) bytes
```