### PR TITLE
bump mros2 to v0.5.4

### DIFF
--- a/mros2.lib
+++ b/mros2.lib
@@ -1,1 +1,1 @@
-https://github.com/mROS-base/mros2#v0.5.3
+https://github.com/mROS-base/mros2#v0.5.4


### PR DESCRIPTION
The operation with v0.5.4 has been confirmed at https://github.com/mROS-base/mros2/pull/55 
So I will merge this soon.