### PR TITLE
Doubled the maximum number of sockets to go along with the DHCP client.

### DIFF
--- a/mbed_app.json
+++ b/mbed_app.json
@@ -3,7 +3,9 @@
     "*": {
       "platform.stdio-baud-rate": 115200,
       "rtos.main-thread-stack-size": 8192,
-      "lwip.pbuf-pool-size": 20
+      "lwip.pbuf-pool-size": 20,
+      "lwip.socket-max": 8,
+      "lwip.udp-socket-max": 8
     },
     "K64F": {
       "platform.stdio-baud-rate": 9600


### PR DESCRIPTION
The cause of the problem which was found in the issue below seems to be a lack of the system resource for sockets, which are additionally used for the DHCP client.

https://github.com/mROS-base/mros2-mbed/issues/43

I found that the parameters related to the maximum socket number below should be increased to 5 from 4(default).
- lwip.socket-max
- lwip.udp-socket-max

But, in this PR, I doubled them (4->8) in case we might need further additional sockets for the application in the future.

